### PR TITLE
Bug Fix: Passing props from getInitialProps methods in NextJS page components

### DIFF
--- a/components/router/with-react-router.js
+++ b/components/router/with-react-router.js
@@ -5,11 +5,13 @@ const isServer = typeof window === 'undefined';
 export default App => {
     return class AppWithReactRouter extends React.Component {
         static async getInitialProps(appContext) {
-            let nextJsRenderError;
+            const { pageProps } = await App.getInitialProps(appContext);
+
             /*
                 If we fallback to nexjs to render a page and throws an error in the response,
                 we catche it here and pass it to the props of the _app.js
             */
+            let nextJsRenderError;
             if (appContext.ctx.res.statusCode > 200) {
                 nextJsRenderError = {
                     statusCode: appContext.ctx.res.statusCode
@@ -25,7 +27,8 @@ export default App => {
             return {
                 originalUrl,
                 context: locals.context || {},
-                nextJsRenderError
+                nextJsRenderError,
+                pageProps
             };
         }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -28,7 +28,7 @@ function DotCMSStatus({ status }) {
     );
 }
 
-function RoutedComponent({ Component, pageRender, nav, isBeingEditFromDotCMS, location: { pathname } }) {
+function RoutedComponent({ Component, pageRender, nav, isBeingEditFromDotCMS, location: { pathname }, pageProps }) {
     const isFirstRun = useRef(true);
     const [requestedPage, setRequestedPage] = useState(null);
     const [clientRequestError, setClientRequestError] = useState(null);
@@ -83,7 +83,20 @@ function RoutedComponent({ Component, pageRender, nav, isBeingEditFromDotCMS, lo
         return <Error message={message} statusCode={statusCode} />;
     }
 
-    return <Component pageRender={requestedPage || pageRender} nav={nav} />;
+    // NextJS props from getInitialProps
+    const props = { ...pageProps };
+
+    // DotCMS page object
+    if (requestedPage || pageRender) {
+        props.pageRender = requestedPage || pageRender;
+    }
+
+    // DotCMS nav object
+    if (nav) {
+        props.nav = nav;
+    }
+
+    return <Component {...props} />;
 }
 
 class MyApp extends App {
@@ -91,7 +104,8 @@ class MyApp extends App {
         const {
             Component,
             router: { query },
-            nextJsRenderError
+            nextJsRenderError,
+            pageProps
         } = this.props;
 
         /*
@@ -112,8 +126,9 @@ class MyApp extends App {
                                 <>
                                     <RoutedComponent
                                         Component={Component}
-                                        pageRender={query.pageRender}
                                         nav={query.nav}
+                                        pageProps={pageProps}
+                                        pageRender={query.pageRender}
                                         {...routerProps}
                                     ></RoutedComponent>
                                 </>


### PR DESCRIPTION
While working in rendering nextjs pages using DotCMS pages @alfredo-dotcms found out that we weren't passing the fetched data in the `getInitialProps` of the NextJS page components, this is to fix that.