### PR TITLE
Prevent passing language things from the server

### DIFF
--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -1,5 +1,5 @@
 import Nav from './Nav/Nav';
-import LocaleDropdown from "./LocaleDropdown";
+import LocaleDropdown from './LocaleDropdown';
 
 const Header = () => {
     return (
@@ -41,7 +41,10 @@ const Header = () => {
                                                 <span className="icon mdi mdi-map-marker"></span>
                                             </div>
                                             <div className="unit-body">
-                                                <a href="#">3059 Grand Avenue, Suite 300 Miami, FL, 33133 USA</a>
+                                                <a href="#">
+                                                    3059 Grand Avenue, Suite 300 Miami, FL, 33133
+                                                    USA
+                                                </a>
                                             </div>
                                         </div>
                                     </li>
@@ -61,13 +64,16 @@ const Header = () => {
                                                 <span className="icon mdi mdi-email-outline"></span>
                                             </div>
                                             <div className="unit-body">
-                                                <a href="mailto: info@dotcms.com">info@dotcms.com</a>
+                                                <a href="mailto: info@dotcms.com">
+                                                    info@dotcms.com
+                                                </a>
                                             </div>
                                         </div>
                                     </li>
                                 </ul>
-                                <LocaleDropdown />
                                 <div>
+                                    <LocaleDropdown />
+
                                     {/* CART */}
                                     <a className="basket" href="/store/cart">
                                         <span className="icon mdi mdi-cart-outline"></span>

--- a/components/layout/LocaleDropdown.js
+++ b/components/layout/LocaleDropdown.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import { PageContext } from '../../pages/_app';
 import useDotCMSApi from '../../hooks/useDotCMSApi';
 import { getLanguages } from '../../utils/dotcms';
@@ -10,6 +11,16 @@ const Options = ({ languages }) => {
             {lang.language}
         </option>
     ));
+};
+
+Options.propTypes = {
+    languages: PropTypes.arrayOf(
+        PropTypes.shape({
+            languageCode: PropTypes.string.isRequired,
+            id: PropTypes.string.isRequired,
+            language: PropTypes.string.isRequired
+        }).isRequired
+    ).isRequired
 };
 
 const LocaleDropdown = () => {

--- a/components/layout/LocaleDropdown.js
+++ b/components/layout/LocaleDropdown.js
@@ -1,8 +1,11 @@
 import { PageContext } from '../../pages/_app';
+import useDotCMSApi from '../../hooks/useDotCMSApi';
+import { getLanguages } from '../../utils/dotcms';
+
 import React from 'react';
 
 const Options = ({ languages }) => {
-    return languages.map(lang => (
+    return languages.map((lang) => (
         <option key={lang.languageCode} value={lang.id}>
             {lang.language}
         </option>
@@ -18,17 +21,24 @@ const LocaleDropdown = () => {
         appearance: 'none',
         WebkitAppearance: 'none',
         borderRadius: '0',
-        border:'0',
-        outline:'none',
-        borderLeft: '1px solid #aeb1be',
-        borderRight: '1px solid #aeb1be'
+        border: '0',
+        outline: 'none',
+        borderLeft: '1px solid #aeb1be'
     };
+
+    const [loading, languages] = useDotCMSApi(getLanguages);
 
     return (
         <PageContext.Consumer>
             {({ language }) => (
-                <select style={tempStyle} defaultValue={language.current} onChange={language.set}>
-                    <Options languages={language.options} />
+                <select
+                    style={tempStyle}
+                    defaultValue={language.current}
+                    onChange={({ target }) => {
+                        language.set(target.value);
+                    }}
+                >
+                    <Options languages={languages} />
                 </select>
             )}
         </PageContext.Consumer>

--- a/utils/dotcms/utilities.js
+++ b/utils/dotcms/utilities.js
@@ -29,6 +29,7 @@ const DOTCMS_DOWN = 'DOTCMS_DOWN';
 const DOTCMS_NO_LAYOUT = 'DOTCMS_NO_LAYOUT';
 const DOTCMS_NO_AUTH = 'DOTCMS_NO_AUTH';
 const DOTCMS_CUSTOM_ERROR = 'DOTCMS_CUSTOM_ERROR';
+const LANG_COOKIE_NAME = 'dotSPALang';
 
 class CustomError extends Error {
     constructor(message = '', statusCode = DOTCMS_CUSTOM_ERROR, ...params) {
@@ -52,5 +53,7 @@ module.exports = {
     CustomError,
     getCookie,
     setCookie,
-    errors: { DOTCMS_DOWN, DOTCMS_NO_LAYOUT, DOTCMS_NO_AUTH, DOTCMS_CUSTOM_ERROR }
+    LANG_COOKIE_NAME,
+    errors: { DOTCMS_DOWN, DOTCMS_NO_LAYOUT, DOTCMS_NO_AUTH, DOTCMS_CUSTOM_ERROR },
+    isAPIRequest
 };


### PR DESCRIPTION
We had this problem where we were sending the current lang and options from the server to the client and the thing is that the lang lives in the client in a cookie so we can just get it from there.

Also I think we can fetch the lang options client side since is not something we have to use immediately when the page loads so I just fetch it from the locale dropdown itself

Finally there is no trace of lang handling in the server, the server just get the lang from the request header cookie and fetch the page from dotcms unsing it.