### PR TITLE
fix: don't skip the first page of contentlets

### DIFF
--- a/utils/dotcms/index.js
+++ b/utils/dotcms/index.js
@@ -34,8 +34,8 @@ async function getAllPagesContentlets() {
     let results = current;
 
     while (current.length > 0) {
-        counter = counter + 1;
         current = await getPageList(counter * PAGE_SIZE);
+        counter = counter + 1;
         results = [...results, ...current];
     }
 


### PR DESCRIPTION
The pagination counter increments prior to fetching which caused it to skip the initial page of contentlets.

I copied this code to try it out and noticed a few pages of my application were missing.